### PR TITLE
Add selector for "new OWA".

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -4,7 +4,7 @@ module.exports = (Franz) => {
         const unreadMail = jQuery("span[title*='Inbox'] + div > span").first().text();
 
         // "New" OWA (late 2018)
-        const unreadMailNew = parseInt(jQuery("div[title='Inbox'][role='treeitem']").children("span:contains('unread')").text().replace("unread", ""), 10);
+        const unreadMailNew = parseInt(jQuery("div[title*='Inbox'] > span > span").first().contents().first().text(), 10);
 
         const messageCount = isNaN(unreadMail) ? unreadMailNew : unreadMail;
         Franz.setBadge(messageCount);

--- a/webview.js
+++ b/webview.js
@@ -1,7 +1,13 @@
 module.exports = (Franz) => {
     const getMessages = function getMessages() {
+        // Legacy OWA
         const unreadMail = jQuery("span[title*='Inbox'] + div > span").first().text();
-        Franz.setBadge(unreadMail);
+
+        // "New" OWA (late 2018)
+        const unreadMailNew = parseInt(jQuery("div[title='Inbox'][role='treeitem']").children("span:contains('unread')").text().replace("unread", ""), 10);
+
+        const messageCount = isNaN(unreadMail) ? unreadMailNew : unreadMail;
+        Franz.setBadge(messageCount);
     };
     Franz.loop(getMessages);
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1683889/50020084-b9f14780-ff89-11e8-9237-9598939cfe53.png)
The "New Outlook" has a completely different layout. I wanted to add a secondary selector for the message count to support this.

They're using a bunch of obfuscated classes so I wasn't able to build a jQuery selector on classes. I'm relying on the screen reader prompt for "unread" inside of the "Inbox" `treelistitem` to get the count.

I'm not sure if these classes have any relation to my account, so I'm redacting them, but they don't appear to be useful to build a selector.

![image](https://user-images.githubusercontent.com/1683889/50020105-c8d7fa00-ff89-11e8-985d-acf9bef57ebc.png)

It won't hurt my feelings if you find a more efficient jQuery selector. 😉

I've verified this works as a dev recipe in Franz 5.0 beta 18.

![image](https://user-images.githubusercontent.com/1683889/50020057-a514b400-ff89-11e8-904a-5e28abbfbe91.png)
